### PR TITLE
Workaround for ClassNotFoundException

### DIFF
--- a/src/com/germainz/yourtube/XposedMod.java
+++ b/src/com/germainz/yourtube/XposedMod.java
@@ -4,12 +4,10 @@ import java.util.ArrayList;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
-import de.robv.android.xposed.XC_MethodReplacement;
 import de.robv.android.xposed.XSharedPreferences;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 import static de.robv.android.xposed.XposedHelpers.callMethod;
-import static de.robv.android.xposed.XposedHelpers.callStaticMethod;
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
 import static de.robv.android.xposed.XposedHelpers.findClass;
 import static de.robv.android.xposed.XposedHelpers.getIntField;
@@ -28,6 +26,7 @@ public class XposedMod implements IXposedHookLoadPackage {
 
     private static boolean sNewVideo = true;
     private static ArrayList<Integer> sStreamQualities;
+    private static XC_MethodHook.Unhook paneHook;
 
     @Override
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
@@ -39,11 +38,15 @@ public class XposedMod implements IXposedHookLoadPackage {
         // Default pane.
         // =============
 
-        findAndHookMethod("com.google.android.apps.youtube.app.WatchWhileActivity", lpparam.classLoader, "L",
-                new XC_MethodReplacement() {
-                    @Override
-                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
-                        String paneString = prefs.getString(PREF_DEFAULT_PANE, DEFAULT_PANE);
+        paneHook = findAndHookMethod(findClass("fia", lpparam.classLoader), "a", String.class, new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                if (param.args[0].equals("FEwhat_to_watch")) {
+                    // change pane only on initial start up
+                    paneHook.unhook();
+                }
+
+                String paneString = prefs.getString(PREF_DEFAULT_PANE, DEFAULT_PANE);
                         /* Pane ID:
                            What to watch: FEwhat_to_watch
                            Subscriptions: FEsubscriptions
@@ -54,18 +57,14 @@ public class XposedMod implements IXposedHookLoadPackage {
                            Subscriptions: <subscription_id>
                                Get subscriptions id from: https://www.youtube.com/channel/subscription_id
                            Browse channels: FEguide_builder */
-                        if (paneString.equals(PANE_PLAYLIST))
-                            paneString = "VL" + prefs.getString(PREF_PLAYLIST, "");
-                        else if (paneString.equals(PANE_SUBSCRIPTION))
-                            paneString = prefs.getString(PREF_SUBSCRIPTION, "");
+                if (paneString.equals(PANE_PLAYLIST))
+                    paneString = "VL" + prefs.getString(PREF_PLAYLIST, "");
+                else if (paneString.equals(PANE_SUBSCRIPTION))
+                    paneString = prefs.getString(PREF_SUBSCRIPTION, "");
 
-                        Class navigationClass = findClass("a", lpparam.classLoader);
-                        Class innertubeClass = findClass("fia", lpparam.classLoader);
-                        Object paneFromString = callStaticMethod(innertubeClass, "a", paneString);
-                        return callStaticMethod(navigationClass, "a", paneFromString, false);
-                    }
-                }
-        );
+                param.args[0] = paneString;
+            }
+        });
 
         // Override compatibility checks.
         // ==============================

--- a/src/com/germainz/yourtube/XposedMod.java
+++ b/src/com/germainz/yourtube/XposedMod.java
@@ -26,7 +26,7 @@ public class XposedMod implements IXposedHookLoadPackage {
 
     private static boolean sNewVideo = true;
     private static ArrayList<Integer> sStreamQualities;
-    private static XC_MethodHook.Unhook paneHook;
+    private static XC_MethodHook.Unhook sPaneHook;
 
     @Override
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
@@ -38,12 +38,12 @@ public class XposedMod implements IXposedHookLoadPackage {
         // Default pane.
         // =============
 
-        paneHook = findAndHookMethod(findClass("fia", lpparam.classLoader), "a", String.class, new XC_MethodHook() {
+        sPaneHook = findAndHookMethod(findClass("fia", lpparam.classLoader), "a", String.class, new XC_MethodHook() {
             @Override
             protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
                 if (param.args[0].equals("FEwhat_to_watch")) {
                     // change pane only on initial start up
-                    paneHook.unhook();
+                    sPaneHook.unhook();
                 }
 
                 String paneString = prefs.getString(PREF_DEFAULT_PANE, DEFAULT_PANE);


### PR DESCRIPTION
Instead of replacing the method which returns the startup pane, hook the method which gets the pane by String. So in this case when the method receives a String "FEwhat_to_watch" which is usually the case on the first launch, replace it with our own pane string. After that unhook the method, just in case it's needed somewhere else.

I've tested this for the subscription pane only but it worked. It seems like fia.a(String) is only called when launching the app. It's not called when selecting an item from the menu. If you open a web link which opens YT fia.a(String) get's called but it immediately switches to the video/channel/playlist... so the user won't see anything different.

Please test it with other configurations, you know what to test better than me (or release a beta first).
Hopefully I was able to help you, have a nice start in the week!